### PR TITLE
feat: Remove React APIs removed in v19

### DIFF
--- a/README.md
+++ b/README.md
@@ -349,24 +349,6 @@ export default () => {
 };
 ```
 
-### Without React
-
-For usability in non-React apps, we provide a thin wrapper around the React component. The viewer's constructor accepts two arguments:
-
-- `element`: either an element id or an [HTMLElement](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement)
-- `props`: props as documented [above](#optionsprops)
-
-```js
-const element = document.getElementById("root");
-const viewer = seqviz.Viewer(element, props);
-// Render the viewer to the DOM at the node passed in $element`.
-viewer.render();
-// To later update the viewer's configuration and re-renders.
-viewer.setState(props);
-// To render the viewer, eg for server-side rendering, and returns it as an HTML string.
-viewer.renderToString();
-```
-
 ## Contact Us
 
 This library is maintained by <!-- pkg-author(cmd:) -->[Lattice Automation](https://latticeautomation.com/)<!-- /pkg-author -->.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@asimovbio/seqviz",
-  "version": "3.10.15",
+  "version": "3.10.16",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@asimovbio/seqviz",
-      "version": "3.10.15",
+      "version": "3.10.16",
       "license": "MIT",
       "dependencies": {
         "react-resize-detector": "^7.1.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@asimovbio/seqviz",
   "description": "A viewer for DNA, RNA, and protein sequences that supports many input formats",
-  "version": "3.10.15",
+  "version": "3.10.16",
   "module": "dist/index.mjs",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,6 @@
-import * as React from "react";
-import * as ReactDOM from "react-dom";
-import { renderToString as reactRenderToString } from "react-dom/server";
-
 import Circular from "./Circular/Circular";
 import Linear from "./Linear/Linear";
-import SeqViz, { SeqVizProps } from "./SeqViz";
+import SeqViz from "./SeqViz";
 import enzymes from "./enzymes";
 
 export * from "./colors";
@@ -26,67 +22,3 @@ export type { SeqVizProps } from "./SeqViz";
 export type { CircularProps } from "./Circular/Circular";
 
 export type { LinearProps } from "./Linear/Linear";
-
-/**
- * Return a Viewer object with three properties:
- *  - `render` to an HTML element
- *  - `setState(options)` to update the viewer's internal state
- *  - `renderToString` to return an HTML representation of the Viewer
- */
-const Viewer = (element: string | HTMLElement = "root", options: SeqVizProps) => {
-  // used to keep track of whether to re-render after a "set" call
-  let rendered = false;
-  // get the HTML element by ID or use as is if passed directly
-  let domElement: HTMLElement | null;
-  if (!document) return;
-
-  if (typeof element === "string") {
-    if (document.getElementById(element)) {
-      domElement = document.getElementById(element);
-    } else {
-      throw new Error(`Failed to find an element with ID: ${element}`);
-    }
-  } else {
-    domElement = element;
-  }
-  let viewer = React.createElement(SeqViz, options, null);
-
-  /**
-   * Render the Viewer to the element passed
-   */
-  const render = () => {
-    rendered = true;
-    // eslint-disable-next-line react/no-deprecated
-    ReactDOM.render(viewer, domElement);
-    return viewer;
-  };
-
-  /**
-   * Return an HTML string representation of the viewer
-   */
-  const renderToString = () => {
-    return reactRenderToString(viewer);
-  };
-
-  /**
-   * Update the viewer with new settings. Re-renders if render was already called.
-   */
-  const setState = (state: SeqVizProps) => {
-    options = { ...options, ...state };
-    viewer = React.createElement(SeqViz, options, null);
-
-    if (rendered) {
-      // eslint-disable-next-line react/no-deprecated
-      ReactDOM.render(viewer, domElement);
-    }
-    return viewer;
-  };
-
-  return {
-    render,
-    renderToString,
-    setState,
-  };
-};
-
-export { Viewer };


### PR DESCRIPTION
## Summary

When running `yarn build` in KU on Next 15 / React 19, I'm getting this error 

```
../../node_modules/@asimovbio/seqviz/dist/index.mjs
Attempted import error: 'render' is not exported from 'react-dom' (imported as 'ReactDOM').
```

So let's remove the code we can't use anymore (ReactDOM.render()) and update react-resize-detector to be a React 19 compatible version

## Test Plan

- [x] Provided screenshots of your change or your change has no visual effect
- [x] Manually tested the changes in the UI
- [x] Automated tests have been written, or explain why none were included here:

SeqViz
* `npm install && npm run asimov-build && npm pack --pack-destination ../`

KU
* `yarn add ~/asimov/asimovbio-seqviz-3.10.16.tgz`

<img width="581" height="462" alt="image" src="https://github.com/user-attachments/assets/d2b4ce58-fc0d-45fe-bcaf-ec2e593a7358" />
