### PR TITLE
fix: improve shift+click selection behavior for linear and circular viewers

### DIFF
--- a/src/Linear/Translations.tsx
+++ b/src/Linear/Translations.tsx
@@ -59,7 +59,7 @@ export const TranslationRows = ({
       }
       return (
         <TranslationRow
-          key={`i-${firstBase}`}
+          key={`${i}-${firstBase}`}
           bpsPerBlock={bpsPerBlock}
           charWidth={charWidth}
           elementHeight={elementHeight}
@@ -104,22 +104,17 @@ const TranslationRow = (props: {
 }) => (
   <>
     {props.translations.map((t, i) => (
-      <>
-        <SingleNamedElementAminoacids
-          {...props}
-          key={`translation-linear-${t.id}-${i}-${props.firstBase}-${props.lastBase}`}
-          translation={t}
-        />
+      <React.Fragment key={`translation-linear-${t.id}-${i}-${props.firstBase}-${props.lastBase}`}>
+        <SingleNamedElementAminoacids {...props} translation={t} />
         {t.name && (
           <SingleNamedElementHandle
             {...props}
-            key={`translation-handle-linear-${t.id}-${i}-${props.firstBase}-${props.lastBase}`}
             element={t}
             elements={props.translations}
             index={i}
           />
         )}
-      </>
+      </React.Fragment>
     ))}
   </>
 );

--- a/src/Linear/Translations.tsx
+++ b/src/Linear/Translations.tsx
@@ -106,14 +106,7 @@ const TranslationRow = (props: {
     {props.translations.map((t, i) => (
       <React.Fragment key={`translation-linear-${t.id}-${i}-${props.firstBase}-${props.lastBase}`}>
         <SingleNamedElementAminoacids {...props} translation={t} />
-        {t.name && (
-          <SingleNamedElementHandle
-            {...props}
-            element={t}
-            elements={props.translations}
-            index={i}
-          />
-        )}
+        {t.name && <SingleNamedElementHandle {...props} element={t} elements={props.translations} index={i} />}
       </React.Fragment>
     ))}
   </>

--- a/src/SelectionHandler.tsx
+++ b/src/SelectionHandler.tsx
@@ -686,7 +686,7 @@ export default class SelectionHandler extends React.PureComponent<SelectionHandl
     clickedStart: number,
     clickedEnd: number,
     seqLength: number
-  ): { clockwise: boolean, end: number; start: number; } => {
+  ): { clockwise: boolean; end: number; start: number } => {
     // Helper to check if a point is within a clockwise arc from start to end
     const inClockwiseArc = (point: number, start: number, end: number): boolean => {
       if (start <= end) {

--- a/src/SelectionHandler.tsx
+++ b/src/SelectionHandler.tsx
@@ -164,8 +164,7 @@ export default class SelectionHandler extends React.PureComponent<SelectionHandl
         clockwise = this.selectionClockwise;
 
         // Helper: clockwise distance from 'from' to 'to'
-        const clockwiseDist = (from: number, to: number): number =>
-          to >= from ? to - from : seqLength - from + to;
+        const clockwiseDist = (from: number, to: number): number => (to >= from ? to - from : seqLength - from + to);
 
         // Helper: counter-clockwise distance
         const counterClockwiseDist = (from: number, to: number): number =>
@@ -210,16 +209,19 @@ export default class SelectionHandler extends React.PureComponent<SelectionHandl
         // Determine extension direction based on which arc was picked:
         // - If union starts at anchorStart, we're extending forward (clockwise from anchor)
         // - If union starts at clickedStart, we're extending backward (counter-clockwise from anchor)
-        this.selectionClockwise = (union.start === anchorStart);
+        this.selectionClockwise = union.start === anchorStart;
       }
     }
 
-    this.setSelection({
-      clockwise,
-      end: newEnd,
-      start: newStart,
-      type: "SEQ",
-    }, true);
+    this.setSelection(
+      {
+        clockwise,
+        end: newEnd,
+        start: newStart,
+        type: "SEQ",
+      },
+      true
+    );
 
     this.dragEvent = false;
     this.lastClick = Date.now();
@@ -283,8 +285,8 @@ export default class SelectionHandler extends React.PureComponent<SelectionHandl
 
         // Normal click - select just this element and set anchor range
         const clockwise = direction ? direction === 1 : true;
-        const selectionStart = clockwise ? (start || 0) : (end || 0);
-        const selectionEnd = clockwise ? (end || 0) : (start || 0);
+        const selectionStart = clockwise ? start || 0 : end || 0;
+        const selectionEnd = clockwise ? end || 0 : start || 0;
 
         this.setAnchorRange(selectionStart, selectionEnd);
         this.setSelection({
@@ -301,16 +303,16 @@ export default class SelectionHandler extends React.PureComponent<SelectionHandl
       }
       case "AMINOACID": {
         const aaClockwise = direction ? direction === 1 : true;
-        let selectionStart = aaClockwise ? (start || 0) : (end || 0);
-        let selectionEnd = aaClockwise ? (end || 0) : (start || 0);
-        let clockwise = aaClockwise;
+        let selectionStart = aaClockwise ? start || 0 : end || 0;
+        let selectionEnd = aaClockwise ? end || 0 : start || 0;
+        const clockwise = aaClockwise;
 
         // if they double clicked, select the whole translation
         // https://en.wikipedia.org/wiki/Double-click#Speed_and_timing
         if (msSinceLastClick < 300 && knownRange.parent) {
           knownRange = { ...knownRange.parent, end: knownRange.parent.end || 0, start: knownRange.parent.start || 0 };
-          selectionStart = aaClockwise ? (knownRange.start || 0) : (knownRange.end || 0);
-          selectionEnd = aaClockwise ? (knownRange.end || 0) : (knownRange.start || 0);
+          selectionStart = aaClockwise ? knownRange.start || 0 : knownRange.end || 0;
+          selectionEnd = aaClockwise ? knownRange.end || 0 : knownRange.start || 0;
         } else if (this.handleShiftClickExtend(e, start || 0, end || 0, viewer || "LINEAR")) {
           // Shift+click handled - stop propagation and return
           e.stopPropagation();
@@ -684,7 +686,7 @@ export default class SelectionHandler extends React.PureComponent<SelectionHandl
     clickedStart: number,
     clickedEnd: number,
     seqLength: number
-  ): { start: number; end: number; clockwise: boolean } => {
+  ): { clockwise: boolean, end: number; start: number; } => {
     // Helper to check if a point is within a clockwise arc from start to end
     const inClockwiseArc = (point: number, start: number, end: number): boolean => {
       if (start <= end) {
@@ -709,12 +711,10 @@ export default class SelectionHandler extends React.PureComponent<SelectionHandl
 
     // Check which arcs include all four endpoints (and thus both full ranges)
     const arc1Valid =
-      inClockwiseArc(anchorEnd, anchorStart, clickedEnd) &&
-      inClockwiseArc(clickedStart, anchorStart, clickedEnd);
+      inClockwiseArc(anchorEnd, anchorStart, clickedEnd) && inClockwiseArc(clickedStart, anchorStart, clickedEnd);
 
     const arc2Valid =
-      inClockwiseArc(anchorStart, clickedStart, anchorEnd) &&
-      inClockwiseArc(clickedEnd, clickedStart, anchorEnd);
+      inClockwiseArc(anchorStart, clickedStart, anchorEnd) && inClockwiseArc(clickedEnd, clickedStart, anchorEnd);
 
     // Pick the shortest valid arc
     if (arc1Valid && (!arc2Valid || arc1Len <= arc2Len)) {

--- a/src/SelectionHandler.tsx
+++ b/src/SelectionHandler.tsx
@@ -62,6 +62,13 @@ export default class SelectionHandler extends React.PureComponent<SelectionHandl
   /* unix time of the last click (awful attempt at detecting double clicks) */
   lastClick = Date.now();
 
+  /* anchor range for shift+click selections - tracks both ends of the original selection */
+  selectionAnchorStart: number | null = null;
+  selectionAnchorEnd: number | null = null;
+
+  /* established direction for shift+click - once set, preserved until new anchor */
+  selectionClockwise: boolean | null = null;
+
   /** a map between the id of child elements and their associated SelectRanges */
   idToRange = new Map<string, Selection>();
 
@@ -100,9 +107,133 @@ export default class SelectionHandler extends React.PureComponent<SelectionHandl
 
   /**
    * remove the ref by ID.
+   *
+   * NOTE: We intentionally do NOT remove entries from idToRange on unmount.
+   * This is because React's timing can cause unmount callbacks to fire AFTER
+   * new components have registered, which would incorrectly remove valid entries.
+   * Stale entries are harmless - they'll be overwritten when the block re-registers.
    */
-  removeMountedBlock = (ref: unknown) => {
-    this.idToRange.delete(ref as string);
+  removeMountedBlock = (_ref: unknown) => {
+    // Intentionally empty - see comment above
+  };
+
+  /**
+   * Handle shift+click to extend selection to include a clicked element.
+   * Returns true if this was a shift+click and was handled, false otherwise.
+   */
+  handleShiftClickExtend = (
+    e: SeqVizMouseEvent,
+    clickedStart: number,
+    clickedEnd: number,
+    viewer: "LINEAR" | "CIRCULAR"
+  ): boolean => {
+    const selection = this.context;
+
+    if (!e.shiftKey || selection.start === undefined || selection.end === undefined) {
+      return false;
+    }
+
+    // Use anchor range if available, otherwise fall back to selection boundaries
+    const anchorStart = this.selectionAnchorStart ?? selection.start;
+    const anchorEnd = this.selectionAnchorEnd ?? selection.end;
+    const seqLength = this.props.seq.length;
+
+    let newStart: number;
+    let newEnd: number;
+    let clockwise: boolean;
+
+    if (viewer === "LINEAR") {
+      // LINEAR viewer: simple min/max union, never wrap around
+      newStart = Math.min(anchorStart, clickedStart);
+      newEnd = Math.max(anchorEnd, clickedEnd);
+      clockwise = true;
+    } else {
+      // CIRCULAR viewer: handle wrap-around and direction
+
+      // Check if anchor range is inside the clicked element
+      const anchorInsideClicked = clickedStart <= anchorStart && anchorEnd <= clickedEnd;
+
+      if (anchorInsideClicked) {
+        // Select the entire element since the anchor is inside it
+        newStart = clickedStart;
+        newEnd = clickedEnd;
+        clockwise = true;
+        this.selectionClockwise = null; // Reset since we're selecting a whole element
+      } else if (this.selectionClockwise !== null) {
+        // Direction already established and LOCKED until next non-shift click
+        clockwise = this.selectionClockwise;
+
+        // Helper: clockwise distance from 'from' to 'to'
+        const clockwiseDist = (from: number, to: number): number =>
+          to >= from ? to - from : seqLength - from + to;
+
+        // Helper: counter-clockwise distance
+        const counterClockwiseDist = (from: number, to: number): number =>
+          to <= from ? from - to : from + seqLength - to;
+
+        // Points that must be included in the selection
+        const points = [anchorStart, anchorEnd, clickedStart, clickedEnd];
+
+        if (clockwise) {
+          // Clockwise: fixed start at anchorStart, find furthest point clockwise
+          newStart = anchorStart;
+          newEnd = anchorEnd;
+          let maxDist = 0;
+          for (const p of points) {
+            const dist = clockwiseDist(anchorStart, p);
+            if (dist > maxDist) {
+              maxDist = dist;
+              newEnd = p;
+            }
+          }
+        } else {
+          // Counter-clockwise: fixed start at anchorEnd, find furthest point counter-clockwise
+          newStart = anchorEnd;
+          newEnd = anchorStart;
+          let maxDist = 0;
+          for (const p of points) {
+            const dist = counterClockwiseDist(anchorEnd, p);
+            if (dist > maxDist) {
+              maxDist = dist;
+              newEnd = p;
+            }
+          }
+        }
+      } else {
+        // First shift+click - use UNION with SHORTEST PATH
+        // Calculate the shortest arc that includes both elements fully
+        const union = this.calcCircularUnion(anchorStart, anchorEnd, clickedStart, clickedEnd, seqLength);
+        newStart = union.start;
+        newEnd = union.end;
+        clockwise = union.clockwise;
+
+        // Determine extension direction based on which arc was picked:
+        // - If union starts at anchorStart, we're extending forward (clockwise from anchor)
+        // - If union starts at clickedStart, we're extending backward (counter-clockwise from anchor)
+        this.selectionClockwise = (union.start === anchorStart);
+      }
+    }
+
+    this.setSelection({
+      clockwise,
+      end: newEnd,
+      start: newStart,
+      type: "SEQ",
+    }, true);
+
+    this.dragEvent = false;
+    this.lastClick = Date.now();
+    return true;
+  };
+
+  /**
+   * Set anchor range for future shift+clicks. Normalizes to [min, max].
+   * Clears established direction so next shift+click calculates shortest path.
+   */
+  setAnchorRange = (start: number, end: number) => {
+    this.selectionAnchorStart = Math.min(start, end);
+    this.selectionAnchorEnd = Math.max(start, end);
+    this.selectionClockwise = null; // Reset direction for new anchor
   };
 
   /**
@@ -124,6 +255,7 @@ export default class SelectionHandler extends React.PureComponent<SelectionHandl
     let knownRange = this.dragEvent
       ? this.idToRange.get(e.currentTarget.id) // only look for SeqBlocks
       : this.idToRange.get(e.target.id) || this.idToRange.get(e.currentTarget.id); // elements and SeqBlocks
+
     if (!knownRange) {
       return; // there isn't a known range with the id of the element
     }
@@ -144,11 +276,17 @@ export default class SelectionHandler extends React.PureComponent<SelectionHandl
           setCentralIndex("LINEAR", start || 0);
         }
 
-        // Annotation or find selection range
-        const clockwise = direction ? direction === 1 : true;
-        const selectionStart = clockwise ? start : end;
-        const selectionEnd = clockwise ? end : start;
+        // Handle shift+click to extend selection
+        if (this.handleShiftClickExtend(e, start || 0, end || 0, viewer || "LINEAR")) {
+          return;
+        }
 
+        // Normal click - select just this element and set anchor range
+        const clockwise = direction ? direction === 1 : true;
+        const selectionStart = clockwise ? (start || 0) : (end || 0);
+        const selectionEnd = clockwise ? (end || 0) : (start || 0);
+
+        this.setAnchorRange(selectionStart, selectionEnd);
         this.setSelection({
           ...knownRange,
           clockwise: clockwise,
@@ -162,19 +300,25 @@ export default class SelectionHandler extends React.PureComponent<SelectionHandl
         break;
       }
       case "AMINOACID": {
-        // Annotation or find selection range
-        const clockwise = direction ? direction === 1 : true;
-        let selectionStart = clockwise ? start : end;
-        let selectionEnd = clockwise ? end : start;
+        const aaClockwise = direction ? direction === 1 : true;
+        let selectionStart = aaClockwise ? (start || 0) : (end || 0);
+        let selectionEnd = aaClockwise ? (end || 0) : (start || 0);
+        let clockwise = aaClockwise;
 
         // if they double clicked, select the whole translation
         // https://en.wikipedia.org/wiki/Double-click#Speed_and_timing
         if (msSinceLastClick < 300 && knownRange.parent) {
           knownRange = { ...knownRange.parent, end: knownRange.parent.end || 0, start: knownRange.parent.start || 0 };
-          selectionStart = clockwise ? knownRange.start : knownRange.end;
-          selectionEnd = clockwise ? knownRange.end : knownRange.start;
+          selectionStart = aaClockwise ? (knownRange.start || 0) : (knownRange.end || 0);
+          selectionEnd = aaClockwise ? (knownRange.end || 0) : (knownRange.start || 0);
+        } else if (this.handleShiftClickExtend(e, start || 0, end || 0, viewer || "LINEAR")) {
+          // Shift+click handled - stop propagation and return
+          e.stopPropagation();
+          return;
         }
 
+        // Normal click or double-click - set anchor and selection
+        this.setAnchorRange(selectionStart, selectionEnd);
         this.setSelection({
           ...knownRange,
           clockwise: clockwise,
@@ -248,17 +392,47 @@ export default class SelectionHandler extends React.PureComponent<SelectionHandl
 
     if (e.type === "mousedown" && currBase !== null) {
       // this is the start of a drag event
+      let newStart = currBase;
+      let newEnd = currBase;
+
+      if (e.shiftKey && selection.start !== undefined && selection.end !== undefined) {
+        // Extending selection with shift+click - use anchor range
+        const anchorStart = this.selectionAnchorStart ?? selection.start;
+        const anchorEnd = this.selectionAnchorEnd ?? selection.end;
+
+        if (currBase < anchorStart) {
+          // Extending upstream: move start to clicked position, keep anchor end
+          newStart = currBase;
+          newEnd = anchorEnd;
+        } else if (currBase > anchorEnd) {
+          // Extending downstream: keep anchor start, move end to clicked position
+          newStart = anchorStart;
+          newEnd = currBase;
+        } else {
+          // Clicked within anchor range - shrink selection to point
+          newStart = currBase;
+          newEnd = currBase;
+        }
+      } else {
+        // Normal click - set new anchor range (single point)
+        this.setAnchorRange(currBase, currBase);
+      }
+
       this.setSelection(
         {
           ...defaultSelection,
-          clockwise: clockwiseDrag,
-          end: currBase,
-          start: e.shiftKey ? selection.start : currBase,
+          clockwise: true,
+          end: newEnd,
+          start: newStart,
           type: "SEQ",
         },
         true
       );
-      this.dragEvent = true;
+      // Don't start drag event for shift+click - it's a one-shot selection extension
+      // Starting a drag would cause mousemove to overwrite the selection with stale context values
+      if (!e.shiftKey) {
+        this.dragEvent = true;
+      }
     } else if (this.dragEvent && currBase !== null) {
       // continue a drag event that's currently happening
       this.setSelection({
@@ -285,20 +459,28 @@ export default class SelectionHandler extends React.PureComponent<SelectionHandl
     const seqLength = seq.length;
 
     if (e.type === "mousedown") {
-      const selStart = e.shiftKey ? start || 0 : currBase;
-      const lookahead = e.shiftKey
-        ? this.calcSelectionLength(selStart, currBase, false)
-        : this.calcSelectionLength(selStart, currBase, true); // check clockwise selection length
-      this.selectionStarted = lookahead > 0; // update check for whether there is a prior selection
-      this.resetCircleDragVars(selStart); // begin drag event
-      setCentralIndex?.("LINEAR", selStart);
+      // Handle shift+click to extend selection using same logic as annotations
+      if (e.shiftKey && selection.start !== undefined && selection.end !== undefined) {
+        // Use handleShiftClickExtend for consistent shortest-path behavior
+        if (this.handleShiftClickExtend(e, currBase, currBase, "CIRCULAR")) {
+          return;
+        }
+      }
+
+      // Normal click - set new anchor and start drag
+      const lookahead = this.calcSelectionLength(currBase, currBase, true);
+      this.selectionStarted = lookahead > 0;
+      this.resetCircleDragVars(currBase);
+      setCentralIndex?.("LINEAR", currBase);
+
+      this.setAnchorRange(currBase, currBase);
 
       this.setSelection({
         ...defaultSelection,
         clockwise: clockwise,
         end: currBase,
         ref: "",
-        start: selStart,
+        start: currBase,
         type: "SEQ",
       });
     } else if (
@@ -490,6 +672,63 @@ export default class SelectionHandler extends React.PureComponent<SelectionHandl
       return seq.length - start + base;
     }
     return 0;
+  };
+
+  /**
+   * Calculate the shortest union arc that includes both ranges on a circular sequence.
+   * Returns the start, end, and direction of the union arc.
+   */
+  calcCircularUnion = (
+    anchorStart: number,
+    anchorEnd: number,
+    clickedStart: number,
+    clickedEnd: number,
+    seqLength: number
+  ): { start: number; end: number; clockwise: boolean } => {
+    // Helper to check if a point is within a clockwise arc from start to end
+    const inClockwiseArc = (point: number, start: number, end: number): boolean => {
+      if (start <= end) {
+        return point >= start && point <= end;
+      } else {
+        // Arc wraps around origin
+        return point >= start || point <= end;
+      }
+    };
+
+    // Calculate arc length for clockwise arc from start to end
+    const arcLength = (start: number, end: number): number => {
+      return end >= start ? end - start : seqLength - start + end;
+    };
+
+    // Two candidate union arcs:
+    // Arc 1: Clockwise from anchorStart to clickedEnd
+    // Arc 2: Clockwise from clickedStart to anchorEnd
+
+    const arc1Len = arcLength(anchorStart, clickedEnd);
+    const arc2Len = arcLength(clickedStart, anchorEnd);
+
+    // Check which arcs include all four endpoints (and thus both full ranges)
+    const arc1Valid =
+      inClockwiseArc(anchorEnd, anchorStart, clickedEnd) &&
+      inClockwiseArc(clickedStart, anchorStart, clickedEnd);
+
+    const arc2Valid =
+      inClockwiseArc(anchorStart, clickedStart, anchorEnd) &&
+      inClockwiseArc(clickedEnd, clickedStart, anchorEnd);
+
+    // Pick the shortest valid arc
+    if (arc1Valid && (!arc2Valid || arc1Len <= arc2Len)) {
+      return { clockwise: true, end: clickedEnd, start: anchorStart };
+    } else if (arc2Valid) {
+      return { clockwise: true, end: anchorEnd, start: clickedStart };
+    } else {
+      // Fallback - use simple min/max (shouldn't happen for valid ranges)
+      return {
+        clockwise: true,
+        end: Math.max(anchorEnd, clickedEnd),
+        start: Math.min(anchorStart, clickedStart),
+      };
+    }
   };
 
   render() {


### PR DESCRIPTION
## Summary

Completely rewrote the shift+click selection behavior in SeqViz to properly support extending selections across annotations, amino acids, and nucleotides in both the linear sequence viewer and circular plasmid viewer.

**Key features implemented:**
- **Union selection**: Shift+clicking now creates a union (includes both original and clicked element fully), not intersection
- **Anchor range tracking**: The original click position is preserved as an anchor, allowing proper extension in either direction
- **Linear viewer**: Simple left-to-right selection, never wraps around
- **Circular viewer**: Direction-aware selection that respects clockwise/counter-clockwise based on shortest path, then locks that direction for subsequent shift+clicks

## Bugs Fixed

1. Initial selection not working until clicking annotation (React unmount race condition)
2. Shift+click not working for annotations/AAs (no handler existed)
3. Upstream shift+click going "around the loop" (wrong clockwise value)
4. Anchor not preserved across multiple shift+clicks (added anchor tracking)
5. Upstream extension not including original selection (needed anchor range, not single point)
6. Adjacent element boundary creating zero-length selection (>= vs >)
7. Shift+click on nucleotide being overwritten by drag handler (disabled drag for shift+clicks)
8. Reverse-strand annotations breaking shift+click (anchor normalization)

## Why It Was Complex

1. **Circular geometry is non-trivial.** On a circular plasmid, there are always two paths between any two points. Calculating the "shortest arc that contains both elements" requires checking multiple candidate arcs and validating that each arc actually includes all four endpoints.

2. **Selection model vs. user intent.** The selection model uses {start, end, clockwise} to define an arc, but the same physical selection can be represented multiple ways. We had to separate: (1) arc representation and (2) extension direction.

3. **Race conditions with React lifecycle.** React's component unmount timing caused a subtle bug where element deregistration would fire after new elements registered, clearing valid entries. The fix was making removeMountedBlock a no-op.

4. **Reverse-strand annotations.** Annotations on the reverse strand have direction === -1, which swaps their start/end values. Without normalizing anchor values to [min, max], shift+click comparisons failed.

5. **Context staleness.** React Context updates are asynchronous. Shift+clicks cannot start drag events because the subsequent mousemove handler would read stale selection values.

6. **Linear vs. circular needed different logic.** The linear viewer should never wrap around, while the circular viewer must support wrapping.

## Test Plan

**Setup:** Open a construct with annotations, amino acid translations, and both linear + circular viewers visible

### Basic Selection
| Test | Steps | Expected |
|------|-------|----------|
| 1.1 | Fresh reload, click directly on nucleotide sequence | Cursor drops at clicked position |
| 1.2 | Fresh reload, click and drag on nucleotides | Selection highlights drag range |

### Shift+Click Downstream
| Test | Steps | Expected |
|------|-------|----------|
| 2.1 | Click nucleotide at pos 100, shift+click nucleotide at pos 200 | Selection: 100-200 |
| 2.2 | Click annotation, shift+click downstream annotation | Both annotations included |
| 2.3 | Click amino acid, shift+click downstream amino acid | Both AAs included |

### Shift+Click Upstream (Was Broken)
| Test | Steps | Expected |
|------|-------|----------|
| 3.1 | Click nucleotide at pos 200, shift+click nucleotide at pos 100 | Selection: 100-200 (NOT around the loop) |
| 3.2 | Click annotation, shift+click upstream annotation | Both annotations included |

### Anchor Preservation (Multiple Shift+Clicks)
| Test | Steps | Expected |
|------|-------|----------|
| 5.1 | Click at 100, shift+click at 300, shift+click at 200 | Selection: 100-200 (anchor=100 preserved) |
| 5.2 | Click at 100, shift+click at 300, shift+click at 50 | Selection: 50-100 (anchor=100 preserved) |

### Circular Viewer
| Test | Steps | Expected |
|------|-------|----------|
| 7.1 | Click annotation on circular, shift+click another annotation | Both included via shortest path |
| 7.2 | Click on circular, shift+click random spot on circle | Selection extends to clicked position |

### Regression Checks
| Test | Steps | Expected |
|------|-------|----------|
| 9.1 | Double-click an amino acid | Whole translation selected |
| 10.1 | Click and drag across nucleotides | Drag selection works normally |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
